### PR TITLE
Add table of common Hutch data file sizes

### DIFF
--- a/02-data_management_plan.Rmd
+++ b/02-data_management_plan.Rmd
@@ -16,7 +16,7 @@ Your data storage needs will depend greatly on the type of data you are storing 
 | **Type of data** | **Common size for a _single_ file** |
 | Genomics (WGS, WES) |	15-60 GB |
 | Genomics (RNA-seq, scRNA-seq)| 3-25 GB |
-| Imaging (microscopy)	Confocal: 2-3 MB |
+| Imaging (microscopy) |	Confocal: 2-3 MB |
 |:-- | Widefield: 5-8 MB |
 | Imaging (human medical) | 1 MB – 2.5 GB |
 | Flow cytometry |	

--- a/02-data_management_plan.Rmd
+++ b/02-data_management_plan.Rmd
@@ -14,6 +14,7 @@ How you should store and interact with data while doing research.
 Your data storage needs will depend greatly on the type of data you are storing as well as the number of samples. File sizes vary considerably based on the data being stored. A single file can be as small as 1 MB in size (for a PET scan image of the heart) to 60 GB (for an uncompressed fastq of a whole genome sequence). Storing files in a compressed format, especially raw files, can help decrease your storage needs and costs. Below is a table of common types of data and sizes for single files. This list is not comprehensive but instead should be taken as a general guide. You should always get a more specific estimate for your particular project before submitting your grant proposal.
 
 | **Type of data** | **Common size for a _single_ file** |
+|------------------|------------------|
 | Genomics (WGS, WES) |	15-60 GB |
 | Genomics (RNA-seq, scRNA-seq)| 3-25 GB |
 | Imaging (microscopy) |	Confocal: 2-3 MB |

--- a/02-data_management_plan.Rmd
+++ b/02-data_management_plan.Rmd
@@ -17,8 +17,7 @@ Your data storage needs will depend greatly on the type of data you are storing 
 |------------------|------------------|
 | Genomics (WGS, WES) |	15-60 GB |
 | Genomics (RNA-seq, scRNA-seq)| 3-25 GB |
-| Imaging (microscopy) |	Confocal: 2-3 MB |
-|:-- | Widefield: 5-8 MB |
+| Imaging (microscopy) | 2-8 MB |
 | Imaging (human medical) | 1 MB – 2.5 GB |
 | Flow cytometry |	
 | Proteomics | 3-5 MB |

--- a/02-data_management_plan.Rmd
+++ b/02-data_management_plan.Rmd
@@ -9,7 +9,19 @@ ottrpal::set_knitr_image_path()
 # Data Management/Storage Options
 
 ## Data Storage Concerns
-How you should store and interact with data while doing research.  
+How you should store and interact with data while doing research. 
+
+Your data storage needs will depend greatly on the type of data you are storing as well as the number of samples. File sizes vary considerably based on the data being stored. A single file can be as small as 1 MB in size (for a PET scan image of the heart) to 60 GB (for an uncompressed fastq of a whole genome sequence). Storing files in a compressed format, especially raw files, can help decrease your storage needs and costs. Below is a table of common types of data and sizes for single files. This list is not comprehensive but instead should be taken as a general guide. You should always get a more specific estimate for your particular project before submitting your grant proposal.
+
+| **Type of data** | **Common size for a _single_ file** |
+| Genomics (WGS, WES) |	15-60 GB |
+| Genomics (RNA-seq, scRNA-seq)| 3-25 GB |
+| Imaging (microscopy)	Confocal: 2-3 MB |
+|:-- | Widefield: 5-8 MB |
+| Imaging (human medical) | 1 MB – 2.5 GB |
+| Flow cytometry |	
+| Proteomics | 3-5 MB |
+| Clinical trials | 2-25 MB |
 
 ## Data Sharing Repositories
 

--- a/02-data_management_plan.Rmd
+++ b/02-data_management_plan.Rmd
@@ -9,7 +9,7 @@ ottrpal::set_knitr_image_path()
 # Data Management/Storage Options
 
 ## Data Storage Concerns
-How you should store and interact with data while doing research. 
+How should you store and interact with data while doing research?
 
 Your data storage needs will depend greatly on the type of data you are storing as well as the number of samples. File sizes vary considerably based on the data being stored. A single file can be as small as 1 MB in size (for a PET scan image of the heart) to 60 GB (for an uncompressed fastq of a whole genome sequence). Storing files in a compressed format, especially raw files, can help decrease your storage needs and costs. Below is a table of common types of data and sizes for single files. This list is not comprehensive but instead should be taken as a general guide. You should always get a more specific estimate for your particular project before submitting your grant proposal.
 

--- a/resources/dictionary.txt
+++ b/resources/dictionary.txt
@@ -1,3 +1,4 @@
+	
 AnVIL
 apalike
 biospecimen
@@ -8,11 +9,13 @@ Bloomberg
 Bookdown
 ccessible
 citable
+Confocal
 Coursera
 CoV
 curation
 Curation
 css
+cytometry
 Dataport
 Datatrail
 DataTrail
@@ -27,6 +30,7 @@ dropdown
 eusable
 FAIRness
 faq
+fastq
 favicon
 favicon.ico
 FHDaSL
@@ -65,6 +69,7 @@ ottrpal
 Pandoc
 PHS
 presubmission
+Proteomics
 reidentification
 reproducibility
 Reusability
@@ -73,12 +78,16 @@ rmarkdown
 RPPR
 shareable
 SBIR
+scRNA
 STTR
 th
 underserved
 UE
 UE5
 Vivli
+WES
+WGS
+Widefield
 www
 Zenodo
 25th


### PR DESCRIPTION
This branch adds a table of common types of data generated by researchers at the Hutch and a general estimate of the size of one file of each data type. This will need to be updated once Amy has run the size estimates past Shared Resources staff.

This table was added to the beginning of the data_management_plan.Rmd