### PR TITLE
Adding its own Google Analytics property

### DIFF
--- a/GA_Script.Rhtml
+++ b/GA_Script.Rhtml
@@ -1,20 +1,20 @@
   <html>
-  
+
   <head>
   <title>Title</title>
   </head>
-  
+
   <body>
-  
+
   <!-- Global site tag (gtag.js) - Google Analytics -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=G-GZX7GS19YN"></script>
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-DQHHNZ863J"></script>
   <script>
     window.dataLayer = window.dataLayer || [];
     function gtag(){dataLayer.push(arguments);}
     gtag('js', new Date());
-    
-    gtag('config', 'G-GZX7GS19YN');
+
+    gtag('config', 'G-DQHHNZ863J');
   </script>
-      
+
   </body>
   </html>


### PR DESCRIPTION
<!--This PR Template was modified from https://github.com/AlexsLemonade/OpenPBTA-analysis/blob/master/.github/PULL_REQUEST_TEMPLATE.md-->

### Purpose/implementation Section

#### What changes are being implemented in this Pull Request?
I'm proposing we put NIH Data Sharing underneath its own Google Analytics property (separate from hutchdatascience.org) so we can see specifically where users are going and what pages of the course are attracting the most traffic. 


In order to do this, I made a new property underneath hutchdasl@gmail.com account and I'm putting the new property tag here. 

If there's a reason we don't think this is a good idea, then we shouldn't merge this PR. 