### PR TITLE
Get Book.txt auto-generation working

### DIFF
--- a/config_automation.yml
+++ b/config_automation.yml
@@ -21,7 +21,7 @@ render-coursera: no
 
 ## Automate the creation of Book.txt file? TRUE/FALSE?
 ## This is only relevant if render-leanpub is yes, otherwise it will be ignored
-make-book-txt: FALSE
+make-book-txt: TRUE
 
 # What docker image should be used for rendering?
 # The default is jhudsl/course_template:main


### PR DESCRIPTION
The Book.txt file required for Leanpub TOC was not working as it was. Will try to autogenerate it first so the formatting looks okay, then go back and make adjustments as needed.