### PR TITLE
Tiny path change to hopefully fix broken quiz rendering

### DIFF
--- a/.github/workflows/transfer-rendered-files.yml
+++ b/.github/workflows/transfer-rendered-files.yml
@@ -54,7 +54,7 @@ jobs:
           echo $QUIZ_REPO
 
           # Get repo check script
-          svn export --force https://github.com/${GITHUB_REPOSITORY}.git/branches/${GITHUB_REF#refs/heads/}/scripts/git_repo_check.R git_repo_check.R
+          svn export --force https://github.com/${GITHUB_REPOSITORY}/blob/${GITHUB_REF#refs/heads/}/scripts/git_repo_check.R git_repo_check.R
 
           # Run repo check script
           results=$(Rscript --vanilla git_repo_check.R --repo "$GITHUB_REPOSITORY" --git_pat "$GH_PAT")

--- a/.github/workflows/transfer-rendered-files.yml
+++ b/.github/workflows/transfer-rendered-files.yml
@@ -52,7 +52,7 @@ jobs:
         env:
           GH_PAT: ${{ secrets.GH_PAT }}
         run: |
-          sudo apt-get install subversion
+          # sudo apt-get install subversion
 
           # What's the Quizzes repository's name?
           QUIZ_REPO=$(echo ${GITHUB_REPOSITORY} | sed "s/_Bookdown/ /g" | sed "s/_Template/ /g" | awk '{print $1"_Quizzes"}')
@@ -61,6 +61,7 @@ jobs:
           # Get repo check script
           # svn export --force https://github.com/${GITHUB_REPOSITORY}/blob/${GITHUB_REF#refs/heads/}/scripts/git_repo_check.R git_repo_check.R
           # wget https://raw.githubusercontent.com/jhudsl/OTTR_Template/main/scripts/git_repo_check.R
+          ls -a
 
           # Run repo check script
           results=$(Rscript --vanilla scripts/git_repo_check.R --repo "$GITHUB_REPOSITORY" --git_pat "$GH_PAT")
@@ -75,6 +76,14 @@ jobs:
         with:
           repository: ${{ steps.git_repo_check.outputs.leanpub_repo }}
           token: ${{ secrets.GH_PAT }}
+          
+      - name: Scope out Files
+        id: git_repo_check_2
+        env:
+          GH_PAT: ${{ secrets.GH_PAT }}
+        run: |
+          ls -a
+          ls -a ../
 
       - name: Get files from Bookdown repo
         if: ${{ steps.git_repo_check.outputs.git_results == 'TRUE' }}
@@ -83,10 +92,10 @@ jobs:
           GH_PAT: ${{ secrets.GH_PAT }}
         run: |
           # Copy over images folder
-          svn export --force https://github.com/${GITHUB_REPOSITORY}.git/branches/${GITHUB_REF#refs/heads/}/resources/chapt_screen_images resources/chapt_screen_images
+          # svn export --force https://github.com/${GITHUB_REPOSITORY}.git/branches/${GITHUB_REF#refs/heads/}/resources/chapt_screen_images resources/chapt_screen_images
 
           # Copy over _bookdown.yml
-          svn export --force https://github.com/${GITHUB_REPOSITORY}.git/branches/${GITHUB_REF#refs/heads/}/_bookdown.yml _bookdown.yml
+          # svn export --force https://github.com/${GITHUB_REPOSITORY}.git/branches/${GITHUB_REF#refs/heads/}/_bookdown.yml _bookdown.yml
 
       - name: Create PR with resources files
         if: ${{ steps.git_repo_check.outputs.git_results == 'TRUE' }}

--- a/.github/workflows/transfer-rendered-files.yml
+++ b/.github/workflows/transfer-rendered-files.yml
@@ -89,13 +89,13 @@ jobs:
           mkdir -p quizzes/resources/chapt_screen_images
           cp bookdown/resources/chapt_screen_images/* quizzes/resources/chapt_screen_images
           echo "Are files present?"
-          la -a quizzes/resources/chapt_screen_images
+          ls -a quizzes/resources/chapt_screen_images
           
           # Copy over _bookdown.yml
           # svn export --force https://github.com/${GITHUB_REPOSITORY}.git/branches/${GITHUB_REF#refs/heads/}/_bookdown.yml _bookdown.yml
           cp bookdown/_bookdown.yml quizzes/_bookdown.yml
           echo "Are files present?"
-          la -a quizzes/_bookdown.yml
+          ls -a quizzes/_bookdown.yml
           
 
       - name: Create PR with resources files

--- a/.github/workflows/transfer-rendered-files.yml
+++ b/.github/workflows/transfer-rendered-files.yml
@@ -55,7 +55,7 @@ jobs:
 
           # Get repo check script
           # svn export --force https://github.com/${GITHUB_REPOSITORY}/blob/${GITHUB_REF#refs/heads/}/scripts/git_repo_check.R git_repo_check.R
-          wget https://github.com/jhudsl/OTTR_Template/blob/main/scripts/git_repo_check.R 
+          wget https://raw.githubusercontent.com/jhudsl/OTTR_Template/main/scripts/git_repo_check.R
 
           # Run repo check script
           results=$(Rscript --vanilla git_repo_check.R --repo "$GITHUB_REPOSITORY" --git_pat "$GH_PAT")

--- a/.github/workflows/transfer-rendered-files.yml
+++ b/.github/workflows/transfer-rendered-files.yml
@@ -45,6 +45,7 @@ jobs:
       - name: checkout
         uses: actions/checkout@v4
         with:
+          path: main
           token: ${{ secrets.GH_PAT }}
     
       - name: Run git repo check
@@ -61,6 +62,7 @@ jobs:
           # Get repo check script
           # svn export --force https://github.com/${GITHUB_REPOSITORY}/blob/${GITHUB_REF#refs/heads/}/scripts/git_repo_check.R git_repo_check.R
           # wget https://raw.githubusercontent.com/jhudsl/OTTR_Template/main/scripts/git_repo_check.R
+          echo "main repo"
           ls -a
 
           # Run repo check script
@@ -74,6 +76,7 @@ jobs:
         if: ${{ steps.git_repo_check.outputs.git_results == 'TRUE' }}
         uses: actions/checkout@v4
         with:
+          path: quizzes
           repository: ${{ steps.git_repo_check.outputs.leanpub_repo }}
           token: ${{ secrets.GH_PAT }}
           
@@ -82,7 +85,9 @@ jobs:
         env:
           GH_PAT: ${{ secrets.GH_PAT }}
         run: |
+          echo "current:"
           ls -a
+          echo "up one:"
           ls -a ../
 
       - name: Get files from Bookdown repo

--- a/.github/workflows/transfer-rendered-files.yml
+++ b/.github/workflows/transfer-rendered-files.yml
@@ -45,7 +45,7 @@ jobs:
       - name: checkout
         uses: actions/checkout@v4
         with:
-          path: main
+          path: bookdown
           token: ${{ secrets.GH_PAT }}
     
       - name: Run git repo check
@@ -62,11 +62,9 @@ jobs:
           # Get repo check script
           # svn export --force https://github.com/${GITHUB_REPOSITORY}/blob/${GITHUB_REF#refs/heads/}/scripts/git_repo_check.R git_repo_check.R
           # wget https://raw.githubusercontent.com/jhudsl/OTTR_Template/main/scripts/git_repo_check.R
-          echo "main repo"
-          ls -a
 
           # Run repo check script
-          results=$(Rscript --vanilla scripts/git_repo_check.R --repo "$GITHUB_REPOSITORY" --git_pat "$GH_PAT")
+          results=$(Rscript --vanilla bookdown/scripts/git_repo_check.R --repo "$GITHUB_REPOSITORY" --git_pat "$GH_PAT")
           echo $QUIZ_REPO exists: $results
 
           echo "git_results=$results" >> $GITHUB_OUTPUT

--- a/.github/workflows/transfer-rendered-files.yml
+++ b/.github/workflows/transfer-rendered-files.yml
@@ -77,16 +77,6 @@ jobs:
           path: quizzes
           repository: ${{ steps.git_repo_check.outputs.leanpub_repo }}
           token: ${{ secrets.GH_PAT }}
-          
-      - name: Scope out Files
-        id: git_repo_check_2
-        env:
-          GH_PAT: ${{ secrets.GH_PAT }}
-        run: |
-          echo "current:"
-          ls -a
-          echo "up one:"
-          ls -a ../
 
       - name: Get files from Bookdown repo
         if: ${{ steps.git_repo_check.outputs.git_results == 'TRUE' }}
@@ -98,16 +88,22 @@ jobs:
           # svn export --force https://github.com/${GITHUB_REPOSITORY}.git/branches/${GITHUB_REF#refs/heads/}/resources/chapt_screen_images resources/chapt_screen_images
           mkdir -p quizzes/resources/chapt_screen_images
           cp bookdown/resources/chapt_screen_images/* quizzes/resources/chapt_screen_images
+          echo "Are files present?"
+          la -a quizzes/resources/chapt_screen_images
           
           # Copy over _bookdown.yml
           # svn export --force https://github.com/${GITHUB_REPOSITORY}.git/branches/${GITHUB_REF#refs/heads/}/_bookdown.yml _bookdown.yml
           cp bookdown/_bookdown.yml quizzes/_bookdown.yml
+          echo "Are files present?"
+          la -a quizzes/_bookdown.yml
+          
 
       - name: Create PR with resources files
         if: ${{ steps.git_repo_check.outputs.git_results == 'TRUE' }}
         uses: peter-evans/create-pull-request@v3
         id: cpr
         with:
+          path: quizzes # Must create the PR in the Quizzes Repo
           token: ${{ secrets.GH_PAT }}
           commit-message: Copy files from Bookdown repository
           signoff: false

--- a/.github/workflows/transfer-rendered-files.yml
+++ b/.github/workflows/transfer-rendered-files.yml
@@ -54,7 +54,8 @@ jobs:
           echo $QUIZ_REPO
 
           # Get repo check script
-          svn export --force https://github.com/${GITHUB_REPOSITORY}/blob/${GITHUB_REF#refs/heads/}/scripts/git_repo_check.R git_repo_check.R
+          # svn export --force https://github.com/${GITHUB_REPOSITORY}/blob/${GITHUB_REF#refs/heads/}/scripts/git_repo_check.R git_repo_check.R
+          wget https://github.com/jhudsl/OTTR_Template/blob/main/scripts/git_repo_check.R 
 
           # Run repo check script
           results=$(Rscript --vanilla git_repo_check.R --repo "$GITHUB_REPOSITORY" --git_pat "$GH_PAT")

--- a/.github/workflows/transfer-rendered-files.yml
+++ b/.github/workflows/transfer-rendered-files.yml
@@ -78,13 +78,11 @@ jobs:
         env:
           GH_PAT: ${{ secrets.GH_PAT }}
         run: |
-          # Copy over images folder
-          # svn export --force https://github.com/${GITHUB_REPOSITORY}.git/branches/${GITHUB_REF#refs/heads/}/resources/chapt_screen_images resources/chapt_screen_images
+          # Copy over images folder (from bookdown to quizzes repo)
           mkdir -p quizzes/resources/chapt_screen_images
           cp bookdown/resources/chapt_screen_images/* quizzes/resources/chapt_screen_images
           
-          # Copy over _bookdown.yml
-          # svn export --force https://github.com/${GITHUB_REPOSITORY}.git/branches/${GITHUB_REF#refs/heads/}/_bookdown.yml _bookdown.yml
+          # Copy over _bookdown.yml (from bookdown to quizzes repo)
           cp bookdown/_bookdown.yml quizzes/_bookdown.yml
 
       - name: Create PR with resources files

--- a/.github/workflows/transfer-rendered-files.yml
+++ b/.github/workflows/transfer-rendered-files.yml
@@ -53,15 +53,9 @@ jobs:
         env:
           GH_PAT: ${{ secrets.GH_PAT }}
         run: |
-          # sudo apt-get install subversion
-
           # What's the Quizzes repository's name?
           QUIZ_REPO=$(echo ${GITHUB_REPOSITORY} | sed "s/_Bookdown/ /g" | sed "s/_Template/ /g" | awk '{print $1"_Quizzes"}')
           echo $QUIZ_REPO
-
-          # Get repo check script
-          # svn export --force https://github.com/${GITHUB_REPOSITORY}/blob/${GITHUB_REF#refs/heads/}/scripts/git_repo_check.R git_repo_check.R
-          # wget https://raw.githubusercontent.com/jhudsl/OTTR_Template/main/scripts/git_repo_check.R
 
           # Run repo check script
           results=$(Rscript --vanilla bookdown/scripts/git_repo_check.R --repo "$GITHUB_REPOSITORY" --git_pat "$GH_PAT")
@@ -88,15 +82,10 @@ jobs:
           # svn export --force https://github.com/${GITHUB_REPOSITORY}.git/branches/${GITHUB_REF#refs/heads/}/resources/chapt_screen_images resources/chapt_screen_images
           mkdir -p quizzes/resources/chapt_screen_images
           cp bookdown/resources/chapt_screen_images/* quizzes/resources/chapt_screen_images
-          echo "Are files present?"
-          ls -a quizzes/resources/chapt_screen_images
           
           # Copy over _bookdown.yml
           # svn export --force https://github.com/${GITHUB_REPOSITORY}.git/branches/${GITHUB_REF#refs/heads/}/_bookdown.yml _bookdown.yml
           cp bookdown/_bookdown.yml quizzes/_bookdown.yml
-          echo "Are files present?"
-          ls -a quizzes/_bookdown.yml
-          
 
       - name: Create PR with resources files
         if: ${{ steps.git_repo_check.outputs.git_results == 'TRUE' }}

--- a/.github/workflows/transfer-rendered-files.yml
+++ b/.github/workflows/transfer-rendered-files.yml
@@ -96,9 +96,12 @@ jobs:
         run: |
           # Copy over images folder
           # svn export --force https://github.com/${GITHUB_REPOSITORY}.git/branches/${GITHUB_REF#refs/heads/}/resources/chapt_screen_images resources/chapt_screen_images
-
+          mkdir -p quizzes/resources/chapt_screen_images
+          cp bookdown/resources/chapt_screen_images/* quizzes/resources/chapt_screen_images
+          
           # Copy over _bookdown.yml
           # svn export --force https://github.com/${GITHUB_REPOSITORY}.git/branches/${GITHUB_REF#refs/heads/}/_bookdown.yml _bookdown.yml
+          cp bookdown/_bookdown.yml quizzes/_bookdown.yml
 
       - name: Create PR with resources files
         if: ${{ steps.git_repo_check.outputs.git_results == 'TRUE' }}

--- a/.github/workflows/transfer-rendered-files.yml
+++ b/.github/workflows/transfer-rendered-files.yml
@@ -42,6 +42,11 @@ jobs:
     if: ${{needs.yaml-check.outputs.toggle_coursera == 'yes' || needs.yaml-check.outputs.toggle_leanpub == 'yes'}}
 
     steps:
+      - name: checkout
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GH_PAT }}
+    
       - name: Run git repo check
         id: git_repo_check
         env:
@@ -55,10 +60,10 @@ jobs:
 
           # Get repo check script
           # svn export --force https://github.com/${GITHUB_REPOSITORY}/blob/${GITHUB_REF#refs/heads/}/scripts/git_repo_check.R git_repo_check.R
-          wget https://raw.githubusercontent.com/jhudsl/OTTR_Template/main/scripts/git_repo_check.R
+          # wget https://raw.githubusercontent.com/jhudsl/OTTR_Template/main/scripts/git_repo_check.R
 
           # Run repo check script
-          results=$(Rscript --vanilla git_repo_check.R --repo "$GITHUB_REPOSITORY" --git_pat "$GH_PAT")
+          results=$(Rscript --vanilla scripts/git_repo_check.R --repo "$GITHUB_REPOSITORY" --git_pat "$GH_PAT")
           echo $QUIZ_REPO exists: $results
 
           echo "git_results=$results" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Noticed this problem:
https://github.com/fhdsl/NIH_Data_Sharing/actions/runs/7933483303/job/21662350109
```
Reading package lists...
Building dependency tree...
Reading state information...
subversion is already the newest version (1.13.0-3ubuntu0.1).
0 upgraded, 0 newly installed, 0 to remove and 96 not upgraded.
fhdsl/NIH_Data_Sharing_Quizzes
svn: E170013: Unable to connect to a repository at URL 'https://github.com/fhdsl/NIH_Data_Sharing.git/branches/main/scripts/git_repo_check.R'
svn: E160013: '/fhdsl/NIH_Data_Sharing.git/branches/main/scripts/git_repo_check.R' path not found
Error: Process completed with exit code 1.
```

![Screenshot 2024-02-16 at 10 21 29 AM](https://github.com/fhdsl/NIH_Data_Sharing/assets/15618412/6f446de6-18f2-43f9-a39b-4600d18b4b9e)
